### PR TITLE
Fix old links to awwad.github.io

### DIFF
--- a/design.md
+++ b/design.md
@@ -24,7 +24,7 @@ introduced in a [2010 paper](https://ssl.engineering.nyu.edu/papers/samuel_tuf_c
 by Justin Samuel, Nick Mathewson, Roger Dingledine, and Justin Cappos.
 Under the direction of Cappos at NYU Tandon School of Engineering since 2011,
 TUF has been [adapted](https://theupdateframework.github.io/papers/prevention-rollback-attacks-atc2017.pdf?raw=true) to [protect against threats](https://theupdateframework.github.io/papers/protect-community-repositories-nsdi2016.pdf?raw=true)
-to various types of [software applications](https://awwad.github.io/papers/kuppusamy_escar_16.pdf).
+to various types of [software applications](https://uptane.github.io/papers/kuppusamy_escar_16.pdf).
 
 A central tenet of TUF is **compromise-resilience**, or the ability to minimize the
 extent of the threat posed by any given attack. The building blocks for

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ step will encourage adoption and ensure clear guidance for future
 users. The [design overview](https://docs.google.com/document/d/1pBK--40BCg_ofww4GES0weYFB6tZRedAjUy6PJ4Rgzk/edit#heading=h.ertrftdz3oms),
 [standards documents](https://docs.google.com/document/d/1wjg3hl0iDLNh7jIRaHl3IXhwm0ssOtDje5NemyTBcaw/edit#heading=h.l6lkvdudrui2),
 [deployment considerations](https://docs.google.com/document/d/17wOs-T7mugwte5_Dt-KLGMsp-3_yAARejpFmrAMefSE/edit#heading=h.6t6kk53v3scx),
-[technical papers](https://awwad.github.io/publications.html),
-[security audits](https://awwad.github.io/audits.html), and
+[technical papers](https://uptane.github.io/publications.html),
+[security audits](https://uptane.github.io/audits.html), and
 [a public reference implementation](https://github.com/uptane/uptane)
 are freely available for all to use.


### PR DESCRIPTION
There were a couple of places where the links pointed to the wrong repo.