### PR TITLE
changed pointer to standard

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -26,10 +26,9 @@
 
 - text: Design Documents
   sub:
-    - text: Uptane Standards
-      url: https://uptane.github.io/uptane-standard/uptane-standard.html
-      external: true
-
+    - text: Uptane Standard
+      url: /cvstandard.html
+ 
     - text: Deployment Consideration
       url: https://docs.google.com/document/d/17wOs-T7mugwte5_Dt-KLGMsp-3_yAARejpFmrAMefSE/edit#heading=h.6t6kk53v3scx
       external: true


### PR DESCRIPTION
I removed the link to the standard so instead it will point to the version cover page through which the current version only will be accessed

There will be a few other commits on this branch to complete this cover page.