### PR TITLE
Change navbar to only point to the new deployment doc.

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -30,11 +30,7 @@
       url: /papers/ieee-isto-6100.1.0.0.uptane-standard.html
       external: true
 
-    - text: Deployment Consideration (stable)
-      url: https://docs.google.com/document/d/17wOs-T7mugwte5_Dt-KLGMsp-3_yAARejpFmrAMefSE/edit#heading=h.6t6kk53v3scx
-      external: true
-
-    - text: Deployment Consideration (WIP)
+    - text: Deployment Considerations
       url: https://github.com/uptane/deployment-considerations
       external: true
 


### PR DESCRIPTION
The old google doc is now considered deprecated.

Should we point to something better than just the github repo, though? I see several links in this repo to https://uptane.github.io/deployment/introduction.html, but that link is currently broken. Should we be populating that somehow? I think something is missing here, but I'm not quite sure how to do it myself. @tkfu or @trishankatdatadog do you have better insight here?

Note that I did not change `standardref.md`, which also points to the github repo but also refers to the deployment doc as the "Latest draft version". Is that still how we want to describe it?