### PR TITLE
Migrate navigation to new deployment guidelines

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -12,7 +12,7 @@
     - text: Uptane Design
       url: /design.html
 
-    - text: Uptane:A JDF/Linux Foundation Project
+    - text: "Uptane: A JDF/Linux Foundation Project"
       url: /alliance.html
 
     - text: Timeline
@@ -26,17 +26,8 @@
 
 - text: Design Documents
   sub:
-    - text: Uptane Standards
+    - text: Uptane Standard
       url: /papers/ieee-isto-6100.1.0.0.uptane-standard.html
-      external: true
-
-    - text: Deployment Consideration (stable)
-      url: https://docs.google.com/document/d/17wOs-T7mugwte5_Dt-KLGMsp-3_yAARejpFmrAMefSE/edit#heading=h.6t6kk53v3scx
-      external: true
-
-    - text: Deployment Consideration (WIP)
-      url: https://github.com/uptane/deployment-considerations
-      external: true
 
     - text: POUF Guidelines
       url: /pouf.html
@@ -46,18 +37,31 @@
    
     - text: Uptane Standards Reference Center
       url: /standardref.html
-      
-- text: Deployment
+
+
+- text: Deployment Considerations
   sub:
+    - text: Introduction
+      url: /deployment-considerations/index.html
+    - text: Preparing ECUs
+      url: /deployment-considerations/ecus.html
+    - text: Preparing servers
+      url: /deployment-considerations/repositories.html
+    - text: Key management and metadata expiration
+      url: /deployment-considerations/key_management.html
+    - text: Normal operating guidelines
+      url: /deployment-considerations/normal_operation.html
+    - text: Exceptional operations
+      url: /deployment-considerations/exceptional_operations.html
+    - text: Customizing Uptane
+      url: /deployment-considerations/customizations.html
+    - text: Other security considerations
+      url: /deployment-considerations/security_considerations.html
+    - text: ASN.1 examples for metadata syntax
+      url: /deployment-considerations/asn1_examples.html
     - text: Reference Implementation and Demonstration Code
       url: https://github.com/uptane/uptane
       external: true
-
-    - text: Adoptions
-      url: /adoptions.html
-
-    - text: Security Audits
-      url: /audits.html
 
 - text: Learn More
   sub:
@@ -67,8 +71,15 @@
     - text: Audio-Visuals
       url: /audio.html
 
+    - text: Adoptions
+      url: /adoptions.html
+
+    - text: Security Audits
+      url: /audits.html
+
+    - text: Participate
+      url: /participate.html
+
 - text: Press
   url: /press.html
 
-- text: Participate
-  url: /participate.html

--- a/standardref.md
+++ b/standardref.md
@@ -7,7 +7,7 @@ This page contains links to all official versions of the Uptane Standard and rel
 IEEE-ISTO: 6100.1.0.0 Uptane Standard for Design and Implementation   [(HTML)](papers/ieee-isto-6100.1.0.0.uptane-standard.html)  [(PDF)](papers/ieee-isto-6100.1.0.0.uptane-standard.pdf)
 
 #### **Uptane Deployment Best Practices**
-[Deployment considerations: Latest draft version](https://github.com/uptane/deployment-considerations)
+[Deployment considerations](https://github.com/uptane/deployment-considerations)
 *In Development*
 
 #### **Uptane Test Plan**


### PR DESCRIPTION
So, the idea here is to give us the flexibility to work on deployment guidelines in their own repo, but still have it look as though it's part of the main site. 

We do this via a Stupid Hack™: we just make both repos build a jekyll site with an identical navbar.

This requires that any changes in the navbar be replicated in both repos; this choice was made so that we could easily work on the draft version, but have it easily deployed for viewing and comments. Now that the deployment guidelines are more stable we could consider moving the content over to this repo and getting rid of the Stupid Hack™, but that's an unimportant discussion for another day.