### PR TITLE
Add a placeholder page for deployment in the location specified in the released 1.0.0 standard

### DIFF
--- a/deployment/introduction.md
+++ b/deployment/introduction.md
@@ -1,0 +1,8 @@
+---
+layout: default
+css_id: adoptions
+---
+
+# Deployment Considerations
+
+This page has moved. Its contents can now be found [here](https://uptane.github.io/deployment-considerations/index.html).


### PR DESCRIPTION
The official 1.0.0 standard points to https://uptane.github.io/deployment/introduction.html as the location of the deployment pages, which currently results in a 404. This PR just adds a simple placeholder redirecting the user to the correct location.