### PR TITLE
changed DHS grant to past tense

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ see LICENSE and LICENSE-MIT.
 This project is managed by Prof. Justin Cappos and other members of the [Secure
 Systems Lab](https://ssl.engineering.nyu.edu/) at NYU.
 
-Uptane is supported by U.S. Department of Homeland Security grants D15PC00239 and
+Uptane was initiated with support from the U.S. Department of Homeland Security grants D15PC00239 and
 D15PC00302. The views and conclusions contained herein are the authors’ and should
 not be interpreted as necessarily representing the official policies or endorsements,
 either expressed or implied, of the U.S. Department of Homeland Security (DHS)

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,7 @@
 </p>
 
 <p class="acknowledgements">
-  Uptane is supported by U.S. Department of Homeland Security grants
+  Uptane was initiated with support from U.S. Department of Homeland Security grants
   D15PC00239 and D15PC00302. The views and conclusions contained herein 
   are the authors’ and should not be interpreted as necessarily representing the 
   official policies or endorsements, either expressed or implied, of the U.S. 


### PR DESCRIPTION
Clarifies that Uptane is no longer supported by DHS