### PR TITLE
Update links to repos hosted in the uptane namespace.

### DIFF
--- a/adoptions.md
+++ b/adoptions.md
@@ -11,13 +11,7 @@ its implementation in millions of vehicles. While the automotive industry
 is legendarily secretive, we can acknowledge a few
 parties.
 
-First, Uptane is incorporated in
-[Automotive Grade Linux](https://www.automotivelinux.org/), which is
-supported by
-[major OEMs and suppliers](https://www.automotivelinux.org/about/members/).
-This is via HERE's [aktualizr](https://github.com/advancedtelematic/aktualizr)
-implementation, which is also integrated in [GENIVI](https://www.genivi.org/).
-
+First, Uptane is incorporated in [Automotive Grade Linux](https://www.automotivelinux.org/), which is supported by [major OEMs and suppliers](https://www.automotivelinux.org/about/members/). This is via [aktualizr](https://github.com/uptane/aktualizr), which is also integrated into the [OTA Community Edition](https://github.com/uptane/ota-community-edition/) and [GENIVI](https://www.genivi.org/).
 
 Interested parties that wish to purchase Uptane compatible components can
 speak with a number of suppliers, including:
@@ -25,7 +19,7 @@ speak with a number of suppliers, including:
 * Advanced Telematic Systems (ATS), now part of
 [HERE Technologies](https://www.here.com/), integrated Uptane
 into its OTA solution, [HERE OTA Connect](https://docs.ota.here.com/index.html)
-(formerly known as ATS Garage).
+(formerly known as ATS Garage), which includes [aktualizr](https://github.com/uptane/aktualizr).
 ATS/HERE was the first European third-party supplier to publicly
 adopt the Uptane framework.
 

--- a/adoptions.md
+++ b/adoptions.md
@@ -11,7 +11,7 @@ its implementation in millions of vehicles. While the automotive industry
 is legendarily secretive, we can acknowledge a few
 parties.
 
-First, Uptane is incorporated in [Automotive Grade Linux](https://www.automotivelinux.org/), which is supported by [major OEMs and suppliers](https://www.automotivelinux.org/about/members/). This is via [aktualizr](https://github.com/uptane/aktualizr), which is also integrated into the [OTA Community Edition](https://github.com/uptane/ota-community-edition/) and [GENIVI](https://www.genivi.org/).
+First, Uptane is incorporated in [Automotive Grade Linux](https://www.automotivelinux.org/), which is supported by [major OEMs and suppliers](https://www.automotivelinux.org/about/members/). Uptane's presence in AGL is via [aktualizr](https://github.com/uptane/aktualizr), which is also integrated into the [OTA Community Edition](https://github.com/uptane/ota-community-edition/) and [GENIVI](https://www.genivi.org/).
 
 Interested parties that wish to purchase Uptane compatible components can
 speak with a number of suppliers, including:

--- a/governance.md
+++ b/governance.md
@@ -12,7 +12,7 @@ This document covers Uptane's governance and committer process. It also lists th
 In July of 2018, Uptane was officially adopted into IEEE's Industry Standards
 and Technology Organization (ISTO) as the non-profit Uptane Alliance. The goal of the Alliance was to standardize the Uptane open-source software in order to ensure that manufacturers and suppliers follow best practices for updates within the automotive industry.
 
-After releasing V. 1.0.0. of the Standard, Uptane formally affiliated with the Linux Foundation as a Joint Development Foundation project. As Joint Development Foundation Projects, LLC, Uptane Series, the project is overseen by a Steering Committee, and is governed by a set of bylaws. The Steering Committee members are:
+After releasing v1.0.0 of the Standard, Uptane formally affiliated with the Linux Foundation as a Joint Development Foundation project. As Joint Development Foundation Projects, LLC, Uptane Series, the project is overseen by a Steering Committee, and is governed by a set of bylaws. The Steering Committee members are:
 
 * Justin Cappos of NYU Tandon School of Engineering
 * Ira McDonald of High North Inc.
@@ -35,22 +35,3 @@ The following industry representatives serve in an advisory capacity for Uptane.
 * Tom Forest of General Motors
 * Trishank Karthik Kuppusamy of Datadog and New York University
 
-
-### Maintainership and Consensus Builder (reference implementation)
-
-The reference implementation for the project is maintained by the people indicated in
-[MAINTAINERS](https://uptane.github.io/people.html). A maintainer is expected to (1) submit and review GitHub pull requests and (2) open issues or [submit vulnerability
-reports](https://github.com/theupdateframework/tuf#security-issues-and-bugs).
-A maintainer has the authority to approve or reject pull requests submitted by
-contributors.  The project's Consensus Builder (CB) is
-[Justin Cappos](mailto:jcappos@nyu.edu) (JustinCappos on github).
-
-### Changes in maintainership (reference implementation)
-
-A contributor to the project must express interest in becoming a maintainer.
-The CB has the authority to add or remove maintainers for the reference
-implementation.
-
-### Changes in governance (reference implementation)
-
-The CB supervises changes in governance for the reference implementation.

--- a/participate.md
+++ b/participate.md
@@ -28,14 +28,9 @@ organization does wish to join this group, please contact jcappos@nyu.edu
 for more information on how to do so.)
 
 ### Code Contributions
-To make contributions to the reference
-implementation or the demonstration code, please submit a GitHub
-pull request to this repository using
-[these development instructions](https://github.com/secure-systems-lab/lab-guidelines/blob/master/dev-workflow.md).
-If submitting any new software feature or change, please include unit tests.
+To make contributions to this or any other Uptane repository on GitHub, please submit a pull request to this repository using [these development instructions](https://github.com/secure-systems-lab/lab-guidelines/blob/master/dev-workflow.md). If submitting any new software feature or change, please include or update appropriate unit tests.
 
-All submitted pull requests undergo review and automated testing, including, but
-not limited to:
+All submitted pull requests undergo review and automated testing, including, but not limited to:
 * Unit and build testing via Travis CI
 * Review by one or more maintainers
 
@@ -47,9 +42,9 @@ on this.
 
 ### Security Audits
 
-We welcome security audits of the Uptane design, or vulnerability reports of
-the design or the code in this repository. Please contact lab director
-[Justin Cappos](mailto:jcappos@nyu.edu) or maintainer [Sebastien Awwad](mailto: sebastien.awwad@nyu.edu).
+We welcome security audits of the Uptane design and vulnerability reports of
+the design or any code in the [Uptane GitHub namespace](https://github.com/uptane). Please contact lab director
+[Justin Cappos](mailto:jcappos@nyu.edu) or maintainer [Lois Anne DeLong](mailto:lad278@nyu.edu).
 Uptane design and implementation is defined in the [Uptane Standards document](https://uptane.github.io/uptane-standard/uptane-standard.html) and supplemented by the [Deployment Best Practices document](https://uptane.github.io/deployment-considerations/index.html).
 
 Should the information be highly sensitive, auditors / reporters may employ

--- a/people.md
+++ b/people.md
@@ -31,37 +31,6 @@ This group serves in an advisory capacity for Uptane activities.
 * Tom Forest of General Motors
 * Trishank Karthik Kuppusamy of Datadog and New York University
 
-### Reference Implementation Personnel
-
-The reference implementation for Uptane is currently managed by [Justin
-Cappos](https://ssl.engineering.nyu.edu/personalpages/jcappos/) and maintainer [Lois Anne DeLong](mailto:lad278@nyu.edu) at New York
-University's [Secure Systems
-Lab](https://ssl.engineering.nyu.edu/).
-
-Please visit the [governance
-page](https://uptane.github.io/governance.html)
-to learn how project decisions are made, and for a more detailed explanation
-of the project roles used below.
-
-
-**Consensus Builder**:
-
-  *Justin Cappos*
-
-    Email: jcappos@nyu.edu
-
-    GitHub username: @JustinCappos
-
-    PGP fingerprint: E9C0 59EC 0D32 64FA B35F  94AD 465B F9F6 F8EB 475A
-
-**Maintainer**:
-
-  *Lois Anne DeLong*
-
-    Email: lad278@nyu.edu
-
-    GitHub username: @jhdalek55
-
 
 ## Project Contributors  
 

--- a/timeline.md
+++ b/timeline.md
@@ -49,8 +49,8 @@ security by [*Popular Science*](https://www.popsci.com/top-security-innovations-
 [BIG Award for Business](https://www.airbiquity.com/news/press-releases/airbiquity-otamatic-named-2017-new-product-year-business-intelligence-group) in the 2017 New Product of the Year Award category for its
 Uptane-based OTAmatic over-the-air software and data management solution.
 
-**2018**: An open source, C++ implementation of Uptane called [aktualizr](https://github.com/advancedtelematic/aktualizr)
-is developed by Advanced Telematic Systems (since acquired by
+**2018**: An open source, C++ implementation of Uptane called [aktualizr](https://github.com/uptane/aktualizr)
+is developed by Advanced Telematic Systems (subsequently acquired by
 [HERE technologies](https://www.here.com/en)).  aktualizr
 is integrated into [Automotive Grade Linux](https://www.automotivelinux.org/) (AGL),
 a collaborative open source project in which


### PR DESCRIPTION
Also remove reference to the obsolete reference implementation. There were some bits about maintainership that _maybe_ could still apply to the code that is on GitHub, but I didn't want to assume that. I don't think we've had a lot of issues around that lately, so I think for now it's best just to remove that and reconsider at a later time if additional text is necessary.

In the process, I noticed that the [People](https://uptane.github.io/people.html) and [Governance](https://uptane.github.io/governance.html) pages have a lot of redundant material. Can we consider merging those pages, or otherwise removing the duplicate parts?