### PR TITLE
Disable argos screenshot tests

### DIFF
--- a/.github/workflows/argos.yml
+++ b/.github/workflows/argos.yml
@@ -1,10 +1,7 @@
 name: Argos CI Screenshots
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   take-screenshots:


### PR DESCRIPTION
# Summary of Changes

The screenshot tests are currently broken; we're disabling them until someone has a chance to fix them.

